### PR TITLE
 src/xensiv_pas_gas.c: Remove uart assert.

### DIFF
--- a/src/xensiv_pas_gas.c
+++ b/src/xensiv_pas_gas.c
@@ -87,7 +87,6 @@ static int32_t xensiv_pas_gas_i2c_write(const xensiv_pas_gas_t *dev, uint8_t reg
 static int32_t xensiv_pas_gas_uart_read(const xensiv_pas_gas_t *dev, uint8_t reg_addr, uint8_t *data, uint8_t len) {
     xensiv_pas_gas_plat_assert(dev != NULL);
     xensiv_pas_gas_plat_assert(dev->ctx != NULL);
-    xensiv_pas_gas_plat_assert(reg_addr <= XENSIV_PAS_GAS_REG_SENS_RST);
     xensiv_pas_gas_plat_assert(data != NULL);
 
     int32_t res = XENSIV_PAS_GAS_OK;
@@ -125,7 +124,6 @@ static int32_t xensiv_pas_gas_uart_read(const xensiv_pas_gas_t *dev, uint8_t reg
 static int32_t xensiv_pas_gas_uart_write(const xensiv_pas_gas_t *dev, uint8_t reg_addr, const uint8_t *data, uint8_t len) {
     xensiv_pas_gas_plat_assert(dev != NULL);
     xensiv_pas_gas_plat_assert(dev->ctx != NULL);
-    xensiv_pas_gas_plat_assert(reg_addr <= XENSIV_PAS_GAS_REG_SENS_RST);
     xensiv_pas_gas_plat_assert(data != NULL);
 
     int32_t res = XENSIV_PAS_GAS_OK;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Removal of assert in uart since it affects the other registers in A2L and R290